### PR TITLE
Some updates for Investigation, Study and Assay profiles

### DIFF
--- a/profile/isa_ro_crate.md
+++ b/profile/isa_ro_crate.md
@@ -93,6 +93,7 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |citation|COULD|[schema.org/ScholarlyArticle](https://schema.org/ScholarlyArticle)|Publications corresponding with this investigation.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 |mentions|COULD|[schema.org/DefinedTermSet](https://schema.org/DefinedTermSet)|Ontologies referenced in this investigation.|
+|url|COULD|URL|The filename or path of the metadata file describing the investigation. Optional, since in some contexts like an ARC the filename is implicit.|
 
 ### Study
 
@@ -114,6 +115,7 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |dateModified|COULD|DateTime|When the Study was last modified|
 |citation|COULD|[schema.org/ScholarlyArticle](https://schema.org/ScholarlyArticle)|A publication corresponding to the study.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
+|url|COULD|URL|The filename or path of the metadata file describing the study. Optional, since in some contexts like an ARC the filename is implicit.|
 
 ### Assay
 
@@ -132,6 +134,7 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |hasPart|SHOULD|[File](https://schema.org/MediaObject)|The data files resulting from the process sequence|
 |variableMeasured|COULD|Text or [schema.org/PropertyValue](https://schema.org/PropertyValue)|The target variable being measured E.g protein concentration|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
+|url|COULD|URL|The filename or path of the metadata file describing the assay. Optional, since in some contexts like an ARC the filename is implicit.|
 
 
 ### LabProcess

--- a/profile/isa_ro_crate.md
+++ b/profile/isa_ro_crate.md
@@ -88,8 +88,8 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |description|SHOULD|Text|A description of the investigation (e.g. an abstract).|
 |hasPart|SHOULD|[schema.org/Dataset](https://schema.org/Dataset) (Study)|An Investigation object should contain other datasets representing the *studies* of the investigation. They must follow the Study profile.|
 |dateCreated|SHOULD|DateTime|When the Investigation was created|
-|dateModified|SHOULD|DateTime|When the Investigation was last modified|
-|datePublished|COULD|DateTime|When the Investigation was published|
+|datePublished|SHOULD|DateTime|When the Investigation was published|
+|dateModified|COULD|DateTime|When the Investigation was last modified|
 |citation|COULD|[schema.org/ScholarlyArticle](https://schema.org/ScholarlyArticle)|Publications corresponding with this investigation.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 |mentions|COULD|[schema.org/DefinedTermSet](https://schema.org/DefinedTermSet)|Ontologies referenced in this investigation.|
@@ -110,8 +110,8 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |about|SHOULD|[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)|The experimental processes performed in this study.|
 |description|SHOULD|Text|A short description of the study (e.g. an abstract).|
 |dateCreated|SHOULD|DateTime|When the Study was created|
-|dateModified|SHOULD|DateTime|When the Study was last modified|
-|datePublished|COULD|DateTime|When the Study was published|
+|datePublished|SHOULD|DateTime|When the Study was published|
+|dateModified|COULD|DateTime|When the Study was last modified|
 |citation|COULD|[schema.org/ScholarlyArticle](https://schema.org/ScholarlyArticle)|A publication corresponding to the study.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 

--- a/profile/isa_ro_crate.md
+++ b/profile/isa_ro_crate.md
@@ -82,9 +82,9 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |@type |MUST|Text|must be '[schema.org/Dataset](https://schema.org/Dataset)'|
 |@id|MUST|Text or URL|Should be “./”, the investigation object represents the root data entity.|
 |additionalType|MUST|Text or URL|‘Investigation’ or ontology term to identify it as an Investigation|
-|headline|MUST|Text|A title of the investigation (e.g. a paper title).|
-|creator|MUST|[schema.org/Person](https://schema.org/Person)|The creator(s)/authors(s)/owner(s)/PI(s) of the investigation.|
 |identifier|MUST|Text or URL|Identifying descriptor of the investigation (e.g. repository name).|
+|headline|SHOULD|Text|A title of the investigation (e.g. a paper title).|
+|creator|SHOULD|[schema.org/Person](https://schema.org/Person)|The creator(s)/authors(s)/owner(s)/PI(s) of the investigation.|
 |description|SHOULD|Text|A description of the investigation (e.g. an abstract).|
 |hasPart|SHOULD|[schema.org/Dataset](https://schema.org/Dataset) (Study)|An Investigation object should contain other datasets representing the *studies* of the investigation. They must follow the Study profile.|
 |dateCreated|SHOULD|DateTime|When the Investigation was created|
@@ -102,10 +102,10 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |----------|----------|---------------|-------------|
 |@type |MUST|Text|must be '[schema.org/Dataset](https://schema.org/Dataset)'|
 |@id|MUST|Text or URL|Should be a subdirectory corresponding to this study.|
-|additionalType|MUST|Text or URL|‘Study’ or ontology term to identify it as a Study|
-|creator|MUST|[schema.org/Person](https://schema.org/Person)|The performer of the study.|
 |identifier|MUST|Text or URL|Identifying descriptor of the study.|
-|headline|MUST|Text|A title of the study.|
+|additionalType|MUST|Text or URL|‘Study’ or ontology term to identify it as a Study|
+|creator|SHOULD|[schema.org/Person](https://schema.org/Person)|The performer of the study.|
+|headline|SHOULD|Text|A title of the study.|
 |hasPart|SHOULD|[schema.org/Dataset](https://schema.org/Dataset) (Assay) or [File](https://schema.org/MediaObject)|Assays contained in this study or actual data files resulting from the process sequence.|
 |about|SHOULD|[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)|The experimental processes performed in this study.|
 |description|SHOULD|Text|A short description of the study (e.g. an abstract).|
@@ -124,18 +124,13 @@ Is based upon [schema.org/Dataset](https://schema.org/Dataset) and maps to the [
 |@type |MUST|Text|must be '[schema.org/Dataset](https://schema.org/Dataset)'|
 |@id|MUST|Text or URL|Should be a subdirectory corresponding to this assay.|
 |additionalType|MUST|Text or URL|‘Assay’ or ontology term to identify it as an Assay|
-|creator|MUST|[schema.org/Person](https://schema.org/Person)|The performer of the experiments.|
 |identifier|MUST|Text or URL|Identifying descriptor of the assay.|
-|headline|MUST|Text|A title of the assay.|
-|about|MUST|[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)|The experimental processes performed in this assay.|
-|measurementMethod|MUST|URL or [schema.org/DefinedTerm](https://schema.org/DefinedTerm)|Describes the type measurement e.g Complexomics or transcriptomics as an ontology term|
-|measurementTechnique|MUST|URL or [schema.org/DefinedTerm](https://schema.org/DefinedTerm)|Describes the type of technology used to take the measurement, e.g mass spectrometry or deep sequencing|
+|about|SHOULD|[bioschemas.org/LabProcess](https://bioschemas.org/LabProcess)|The experimental processes performed in this assay.|
+|creator|SHOULD|[schema.org/Person](https://schema.org/Person)|The performer of the experiments.|
+|measurementMethod|SHOULD|URL or [schema.org/DefinedTerm](https://schema.org/DefinedTerm)|Describes the type measurement e.g Complexomics or transcriptomics as an ontology term|
+|measurementTechnique|SHOULD|URL or [schema.org/DefinedTerm](https://schema.org/DefinedTerm)|Describes the type of technology used to take the measurement, e.g mass spectrometry or deep sequencing|
 |hasPart|SHOULD|[File](https://schema.org/MediaObject)|The data files resulting from the process sequence|
-|description|SHOULD|Text|A short description of the assay (e.g. an abstract)|
 |variableMeasured|COULD|Text or [schema.org/PropertyValue](https://schema.org/PropertyValue)|The target variable being measured E.g protein concentration|
-|dateCreated|SHOULD|DateTime|When the Assay was created|
-|dateModified|SHOULD|DateTime|When the Assay was last modified|
-|citation|COULD|[schema.org/ScholarlyArticle](https://schema.org/ScholarlyArticle)|A publication corresponding to this assay.|
 |comment|COULD|[schema.org/Comment](https://schema.org/Comment)|Comment|
 
 


### PR DESCRIPTION
This PR removes several properties of Assay from the profile that seem to be copied from Study, as they do not correspond to any ISA properties. An exception is the creator/performer of an assay. I kept it in there, since it is also part of an ARC Assay. See Issue https://github.com/nfdi4plants/isa-ro-crate-profile/issues/5 for details.

Furthermore, some Study and Investigation properties were changed from MUST to SHOULD.

@stuzart Could you have a look at this? I think we had some longer discussions about the MUST properties of Investigation, Study and Assay at the Hackathon, but in this form they fit with the ARC tools that export an RO-Crate.

I will probably add further changes for other issues (https://github.com/nfdi4plants/isa-ro-crate-profile/issues/4, https://github.com/nfdi4plants/isa-ro-crate-profile/issues/7, https://github.com/nfdi4plants/isa-ro-crate-profile/issues/9) regarding Investigation, Study and Assay to this PR as well.